### PR TITLE
Remove CloudFormation RequestType from error logs

### DIFF
--- a/glue-database-custom-resource/index.mjs
+++ b/glue-database-custom-resource/index.mjs
@@ -34,7 +34,7 @@ export async function handler(event, context) {
         physicalResourceId = event.PhysicalResourceId;
         result = "SUCCESS";
     } else {
-        reason = `Received unknown RequestType ${event.RequestType}.`;
+        reason = "Unrecognized cloudformation request type received. This custom resource only supports creation and deletion.";
         console.error(reason);
         result = "FAILED";
     }

--- a/glue-table-custom-resource/index.mjs
+++ b/glue-table-custom-resource/index.mjs
@@ -37,7 +37,7 @@ export async function handler(event, context) {
         // For Delete requests, immediately send a SUCCESS response.
         result = "SUCCESS";
     } else {
-        reason = `Received unknown RequestType ${event.RequestType}.`;
+        reason = "Unrecognized cloudformation request type received. This custom resource only supports creation and deletion.";
         console.error(reason);
         result = "FAILED";
     }

--- a/resource-share-arn-acceptance-custom-resource/index.mjs
+++ b/resource-share-arn-acceptance-custom-resource/index.mjs
@@ -31,7 +31,7 @@ export async function handler(event, context) {
         // For Delete requests, immediately send a SUCCESS response.
         result = "SUCCESS";
     } else {
-        reason = `Received unknown RequestType ${event.RequestType}.`;
+        reason = "Unrecognized cloudformation request type received. This custom resource only supports creation and deletion.";
         console.error(reason);
         result = "FAILED";
     }

--- a/ssm-parameter-custom-resource/index.mjs
+++ b/ssm-parameter-custom-resource/index.mjs
@@ -42,7 +42,7 @@ export async function handler(event, context) {
     } else if (event.RequestType === "Delete") {
         [result, reason] = await deleteParameters(event, context);
     } else {
-        reason = `Received unknown RequestType ${event.RequestType}.`;
+        reason = "Unrecognized cloudformation request type received. This custom resource only supports creation and deletion.";
         console.error(reason);
         result = "FAILED";
     }


### PR DESCRIPTION
These error logs were flagged by Amazon Inspector. `event.RequestType` can only contain information passed in by the CloudFormation stack update, but we can remove this variable from the error log and make it more descriptive to resolve the Inspector finding.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
